### PR TITLE
v9 zip file file compatibility & allow custom login screens 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY --chown=fvtt run-server.sh /opt/foundryvtt
 RUN chmod +x /opt/foundryvtt/run-server.sh
 VOLUME /data/foundryvtt
 VOLUME /host
+VOLUME /opt/foundryvtt/app
 EXPOSE 30000
 
 ENTRYPOINT /opt/foundryvtt/run-server.sh

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+# look for a file name foundryvtt-.....zip or FoundryVTT...zip, copy it to 
+# /opt/foundryvtt, unzip and remove it. Then start the foundry app
+
 cd /opt/foundryvtt
-cp /host/foundryvtt*.zip .
-unzip -o foundryvtt*.zip
-rm foundryvtt*.zip
+find /host -type f -name [f,F]oundry[vtt,VTT]*.zip -exec cp '{}' . ';'
+unzip -o *.zip && rm *.zip
 node resources/app/main.js --dataPath=/data/foundryvtt


### PR DESCRIPTION
This PR addresses two issues:
https://github.com/BenjaminPrice/fvtt-docker/issues/24 - v9 zip filename compatibility
https://github.com/BenjaminPrice/fvtt-docker/issues/23 - feature request: expose path for login screen

