### PR TITLE
add support for arm64 platforms such as raspberry pi

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,6 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # setting up QEMU and Buildx in line with this guide:
+      # https://pet2cattle.com/2021/09/build-multiarch-container-github-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Login to docker hub
         if: success()
         uses: actions-hub/docker/login@master
@@ -21,12 +32,13 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build image
+    # build and push based on the same guide:
+    # https://pet2cattle.com/2021/09/build-multiarch-container-github-action
+      - name: Build and push
         if: success()
-        run: docker build -t direckthit/fvtt-docker:${IMAGE_TAG} .
-
-      - name: Push to docker registry
-        if: success()
-        uses: actions-hub/docker@master
+        uses: docker/build-push-action@v2
         with:
-          args: push direckthit/fvtt-docker:${IMAGE_TAG}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: direckthit/fvtt-docker:${IMAGE_TAG} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:16-alpine
 
 RUN deluser node && \
-    mkdir /opt/foundryvtt && \
-    mkdir /data && \
-    mkdir /data/foundryvtt && \
-    adduser --disabled-password fvtt && \
+    mkdir -p /opt/foundryvtt && \
+    mkdir -p /data/foundryvtt && \
+    addgroup fvtt &&\
+    adduser --disabled-password -G fvtt fvtt && \
     chown fvtt:fvtt /opt/foundryvtt && \
     chown fvtt:fvtt /data/foundryvtt && \
     chmod g+s /opt/foundryvtt && \


### PR DESCRIPTION
hi @BenjaminPrice,

I've updated the docker build to work with arm64 platforms. This is in response to requests such as [this one](https://www.reddit.com/r/FoundryVTT/comments/w91kgh/foundry_in_docker_on_raspberry_pi_not/). 

Caveat: 
I have been able to test the build itself, but not the workflow that triggers it as I don't have any experience with creating workflows. 
Would you mind having a look and perhaps testing it? 
