### PR TITLE
Updated Dockerfile to use node 18 image to support Foundry V12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 RUN deluser node && \
     mkdir -p /opt/foundryvtt/resources/app && \


### PR DESCRIPTION
I also created a docker image and pushed it to my docker hub at https://hub.docker.com/r/cryptoxic/fvtt-docker. Feel free to use it or update your docker hub with my updated Dockerfile.