### PR TITLE
Bumped docker image to use node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 RUN deluser node && \
     mkdir -p /opt/foundryvtt/resources/app && \

--- a/run-server.sh
+++ b/run-server.sh
@@ -8,6 +8,11 @@ echo "Copying zip file..."
 find /host -type f -name '[f,F]oundry[vtt,VTT]*.zip' -exec cp '{}' . ';'
 
 echo "Unzipping..."
-unzip -o ./*.zip && rm ./*.zip
+unzip -o ./*.zip -d unpacked && rm ./*.zip
 
-node resources/app/main.js --dataPath=/data/foundryvtt
+echo "Moving to mapped directory"
+mv unpacked/* resources/app/
+
+echo "Starting node"
+cd resources/app
+node main.mjs --dataPath=/data/foundryvtt


### PR DESCRIPTION
Foundry now recommends Node 20.x+ according to their documentation. I have bumped the dockerfile to use a node 20 alpine image. Currently building a docker image.